### PR TITLE
feat: fill days of prev and next month in calendar

### DIFF
--- a/MMM-MonthCalendar.js
+++ b/MMM-MonthCalendar.js
@@ -1,7 +1,9 @@
 Module.register("MMM-MonthCalendar", {
 
     defaults: {
-        updateDelay: 5
+        updateDelay: 5,
+        preFill: true,
+        postFill: true
     },
 
     weekdays: [],
@@ -44,22 +46,55 @@ Module.register("MMM-MonthCalendar", {
     getTemplateData: function() {
         return {
             weekdays: this.weekdays,
+            prefill: this.getPrefill(),
+            postfill: this.getPostfill(),
             days: this.getCalendarDays(),
             today: moment().date()
         }
     },
 
+    getPrefill: function() {
+        /** Fills up the first calendar row with days of the previous month, 
+         * when the config.preFill param is set to true. 
+         * Otherwise it fills with empty space. */
+        let days = [];
+        let lastMonthDayCount = moment().startOf('month').subtract(1, 'day').date();
+        // The weekday int is equal the amount of days we need to fill before
+        let fillBefore = moment().startOf('month').weekday();
+        let fillStart = (lastMonthDayCount + 1) - fillBefore;
+
+        for (let preDay = fillStart; preDay <= lastMonthDayCount; preDay++) {
+            if (this.config.preFill) {
+                days.push(preDay);
+            } else {
+                days.push("");
+            }
+        }
+        return days;
+    },
+
+    getPostfill: function() {
+        /** Fills up the last calendar row with days of the next month, 
+         * when the config.postFill param is set to true. 
+         * Otherwise it fills with empty space. */
+        let days = [];
+        if (!this.config.postFill) return days;
+
+        let lastDay = moment().endOf('month').weekday()
+        let fillAfter = 7 - lastDay;
+
+        for (let postDay = 1; postDay < fillAfter; postDay++) {
+                days.push(postDay);
+        }
+        return days;
+    },
+
     getCalendarDays: function() {
         let days = [];
-        let FillBefore = moment().startOf('month').weekday();
-        for (let i = 0; i < FillBefore; i++) {
-            days.push('');
-        }
+
         for (let day = 1; day <= moment().daysInMonth(); day++) {
             days.push(day);
         }
-        Log.info(days);
         return days;
     }
-
 });

--- a/MMM-MonthCalendar.js
+++ b/MMM-MonthCalendar.js
@@ -2,8 +2,7 @@ Module.register("MMM-MonthCalendar", {
 
     defaults: {
         updateDelay: 5,
-        preFill: true,
-        postFill: true
+        showAdjacentMonths: true
     },
 
     weekdays: [],
@@ -55,7 +54,7 @@ Module.register("MMM-MonthCalendar", {
 
     getPrefill: function() {
         /** Fills up the first calendar row with days of the previous month, 
-         * when the config.preFill param is set to true. 
+         * when the config.showAdjacentMonths param is set to true. 
          * Otherwise it fills with empty space. */
         let days = [];
         let lastMonthDayCount = moment().startOf('month').subtract(1, 'day').date();
@@ -63,22 +62,20 @@ Module.register("MMM-MonthCalendar", {
         let fillBefore = moment().startOf('month').weekday();
         let fillStart = (lastMonthDayCount + 1) - fillBefore;
 
+        if (!this.config.showAdjacentMonths) return Array(fillBefore).fill("");
+
         for (let preDay = fillStart; preDay <= lastMonthDayCount; preDay++) {
-            if (this.config.preFill) {
-                days.push(preDay);
-            } else {
-                days.push("");
-            }
+            days.push(preDay);
         }
         return days;
     },
 
     getPostfill: function() {
         /** Fills up the last calendar row with days of the next month, 
-         * when the config.postFill param is set to true. 
+         * when the config.showAdjacentMonths param is set to true. 
          * Otherwise it fills with empty space. */
         let days = [];
-        if (!this.config.postFill) return days;
+        if (!this.config.showAdjacentMonths) return days;
 
         let lastDay = moment().endOf('month').weekday()
         let fillAfter = 7 - lastDay;

--- a/MMM-MonthCalendar.njk
+++ b/MMM-MonthCalendar.njk
@@ -4,7 +4,13 @@
     {% endfor %}
 </div>
 <div class="calendar-days xsmall">
+    {%for day in prefill %}
+    <div class="prefill">{{ day }}</div>
+    {% endfor %}
     {%for day in days %}
     <div {{ "today" if day == today}}>{{ day }}</div>
+    {% endfor %}
+    {%for day in postfill %}
+    <div class="postfill">{{ day }}</div>
     {% endfor %}
 </div>

--- a/main.css
+++ b/main.css
@@ -11,6 +11,11 @@
     font-weight: 600;
 }
 
+.module.MMM-MonthCalendar .prefill,
+.module.MMM-MonthCalendar .postfill {
+    color: #444444;
+}
+
 .module.MMM-MonthCalendar .calendar-daysinweek div,
 .module.MMM-MonthCalendar .calendar-days div {
     padding: 4px 0;


### PR DESCRIPTION
Instead of only using empty spaces, it would be cool to actually show days of the previous/next month. I implemented a method getPrefill & getPostfill and used them in the njk template. Also both prefill & postfill got their own config value (which defaults to true). They return either empty lists if the setting was set to false or return the days of the prev/next month if the setting was set to true.